### PR TITLE
4.4 집중적인 단일 목적 테스트의 가치

### DIFF
--- a/src/test/java/iloveyouboss/ProfileTest.java
+++ b/src/test/java/iloveyouboss/ProfileTest.java
@@ -2,41 +2,27 @@ package iloveyouboss;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ProfileTest {
 
-    private Profile profile;
-    private BooleanQuestion question;
-    private Criteria criteria;
+    @Test
+    void matches() {
+        Profile profile = new Profile("Bull Hockey, Inc.");
+        Question question = new BooleanQuestion(1, "Got milk?");
 
-    @BeforeEach
-    void create() {
-        profile = new Profile("Bull Hockey, Inc.");
-        question = new BooleanQuestion(1, "Got bonuses?");
+        // must-match 항목이 맞지 않으면 false
+        profile.add(new Answer(question, Bool.FALSE));
+        Criteria criteria = new Criteria();
+        criteria.add(new Criterion(new Answer(question, Bool.TRUE), Weight.MustMatch));
+
+        assertThat(profile.matches(criteria)).isFalse();
+
+        // don't care 항목에 대해서는 true
+        profile.add(new Answer(question, Bool.FALSE));
         criteria = new Criteria();
+        criteria.add(new Criterion(new Answer(question, Bool.TRUE), Weight.DontCare));
+
+        assertThat(profile.matches(criteria)).isTrue();
     }
-
-    @Test
-    void matchAnswersFalseWhenMustMatchCriteriaNotMet() {
-        profile.add(new Answer(question, Bool.FALSE));
-        criteria.add(new Criterion( new Answer(question, Bool.TRUE), Weight.MustMatch));
-
-        boolean matches = profile.matches(criteria);
-
-        assertThat(matches).isFalse();
-    }
-
-    @Test
-    void matchAnswerTrueForAnyDonCareCriteria() {
-        profile.add(new Answer(question, Bool.FALSE));
-        criteria.add(new Criterion( new Answer(question, Bool.TRUE), Weight.DontCare));
-
-        boolean matches = profile.matches(criteria);
-
-        assertThat(matches).isTrue();
-    }
-
 }


### PR DESCRIPTION
- 테스트가 여러 메서드로 나뉘어 있던 기존 방식에서 이렇게 하나의 메서드로 합치게고 주석으로만
케이스를 구분하게 되면 테스트 분리시에 반복되는 초기화 과정의 비용을 줄일 수는 있겠으나,
1. 단언 실패시 어느 동작에서 문제가 발생했는지 빠르게 파악이 불가능하고,
2. 실패한 테스트를 해석하는 데에도 시간이 소요되며,
3. 어느 테스트 케이스까지만 실행되었는지 파악이 불가능하다.